### PR TITLE
Create a separate facade to scrape App Store reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,12 @@
 </p>
 
 # Overview
-Kotlin library to scrape GooglePlay and App Store data. 
-
-Supports proxying requests and content translation.
-Pagination and scraping details are abstracted behind an high-level interface.
+Kotlin library to scrape GooglePlay and App Store data. Forget about scraping details, focus on your users!
+AppVox supports proxying requests and content translation.
 
 # Features
- - Reviews
+ - Review
+    - The Review module Enables you to consume a continuous stream of reviews, 
 
 # Installation
 Only `appvox-core` package is necessary to start using AppVox

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
     <img src="https://user-images.githubusercontent.com/6942446/114973902-f1eb5b00-9eb3-11eb-91e3-814184116b70.png" alt="AppVox" width="300" />
 </p>
 
-
 <p align="center">
     <a href="https://travis-ci.com/fabiouu/AppVox">
         <img src="https://travis-ci.com/fabiouu/AppVox.svg?branch=master" alt="Build Status" />
@@ -22,7 +21,10 @@
 </p>
 
 # Overview
-Kotlin library to scrape GooglePlay and App Store data
+Kotlin library to scrape GooglePlay and App Store data. 
+
+Supports proxying requests and content translation.
+Pagination and scraping details are abstracted behind an high-level interface.
 
 # Features
  - Reviews

--- a/appvox-core/pom.xml
+++ b/appvox-core/pom.xml
@@ -17,6 +17,10 @@
             <artifactId>kotlin-stdlib-jdk8</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>kotlinx-coroutines-core</artifactId>
         </dependency>
@@ -46,8 +50,6 @@
         <dependency>
             <groupId>io.kotest</groupId>
             <artifactId>kotest-assertions-core-jvm</artifactId>
-            <version>4.4.3</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>

--- a/appvox-core/src/main/kotlin/dev/fabiou/appvox/ItunesRss.kt
+++ b/appvox-core/src/main/kotlin/dev/fabiou/appvox/ItunesRss.kt
@@ -1,33 +1,34 @@
 package dev.fabiou.appvox
 
-import dev.fabiou.appvox.appstore.review.service.AppStoreReviewService
 import dev.fabiou.appvox.configuration.Constant.MIN_REQUEST_DELAY
 import dev.fabiou.appvox.configuration.RequestConfiguration
 import dev.fabiou.appvox.exception.AppVoxError
 import dev.fabiou.appvox.exception.AppVoxException
 import dev.fabiou.appvox.review.ReviewIterator
 import dev.fabiou.appvox.review.ReviewRequest
-import dev.fabiou.appvox.review.appstore.AppStoreReviewConverter
-import dev.fabiou.appvox.review.appstore.domain.AppStoreReview
-import dev.fabiou.appvox.review.appstore.domain.AppStoreReviewRequest
+import dev.fabiou.appvox.review.itunesrss.ItunesRssReviewConverter
+import dev.fabiou.appvox.review.itunesrss.ItunesRssReviewService
 import dev.fabiou.appvox.review.itunesrss.constant.AppStoreRegion
+import dev.fabiou.appvox.review.itunesrss.constant.ItunesRssSortType
+import dev.fabiou.appvox.review.itunesrss.domain.ItunesRssReview
+import dev.fabiou.appvox.review.itunesrss.domain.ItunesRssReviewRequest
 import dev.fabiou.appvox.util.HttpUtil
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 /**
- * This class consists of the main methods for interacting with Apple App Store
+ * This class consists of the main methods for interacting with iTunes RSS feed
  *
  * @property config
  * @constructor Create empty App store
  */
-class AppStore(
+class ItunesRss(
     val config: RequestConfiguration = RequestConfiguration(delay = MIN_REQUEST_DELAY)
 ) {
-    private val appStoreReviewService = AppStoreReviewService(config)
+    private val itunesRssReviewService = ItunesRssReviewService(config)
 
-    private val appStoreReviewConverter = AppStoreReviewConverter()
+    private val itunesRssReviewConverter = ItunesRssReviewConverter()
 
     init {
         if (config.proxy?.user != null && config.proxy.password != null) {
@@ -40,24 +41,27 @@ class AppStore(
      *
      * @param appId
      * @param region
+     * @param sortType
      * @return
      */
     fun reviews(
         appId: String,
-        region: AppStoreRegion = AppStoreRegion.UNITED_STATES
-    ): Flow<AppStoreReview> = flow {
+        region: AppStoreRegion = AppStoreRegion.UNITED_STATES,
+        sortType: ItunesRssSortType = ItunesRssSortType.RELEVANT
+    ): Flow<ItunesRssReview> = flow {
 
         if (config.delay < MIN_REQUEST_DELAY) {
             throw AppVoxException(AppVoxError.REQ_DELAY_TOO_SHORT)
         }
 
         val iterator = ReviewIterator(
-            converter = appStoreReviewConverter,
-            service = appStoreReviewService,
+            converter = itunesRssReviewConverter,
+            service = itunesRssReviewService,
             request = ReviewRequest(
-                AppStoreReviewRequest(
+                ItunesRssReviewRequest(
                     appId = appId,
-                    region = region
+                    region = region,
+                    sortType = sortType
                 )
             )
         )

--- a/appvox-core/src/main/kotlin/dev/fabiou/appvox/app/appstore/AppStoreRepository.kt
+++ b/appvox-core/src/main/kotlin/dev/fabiou/appvox/app/appstore/AppStoreRepository.kt
@@ -18,15 +18,11 @@ internal class AppStoreRepository(
 
     @Throws(AppVoxException::class)
     fun getBearerToken(appId: String, region: AppStoreRegion): String {
-        val requestUrl = getUrlDomain() + APP_HP_URL_PATH.format(region.code, appId)
+        val requestUrl = APP_HP_URL_DOMAIN + APP_HP_URL_PATH.format(region.code, appId)
         val responseContent = httpUtils.getRequest(requestUrl = requestUrl, proxyConfig = config.proxy)
         val regex = BEARER_TOKEN_REGEX_PATTERN.toRegex()
         val tokenMatches = regex.find(responseContent)
         val tokenMatch = tokenMatches?.groupValues?.get(1)
         return tokenMatch.orEmpty()
-    }
-
-    internal fun getUrlDomain(): String {
-        return APP_HP_URL_DOMAIN
     }
 }

--- a/appvox-core/src/main/kotlin/dev/fabiou/appvox/configuration/RequestConfiguration.kt
+++ b/appvox-core/src/main/kotlin/dev/fabiou/appvox/configuration/RequestConfiguration.kt
@@ -1,13 +1,13 @@
 package dev.fabiou.appvox.configuration
 
 data class RequestConfiguration(
-        val proxy: Proxy? = null,
-        val delay: Int
+    val proxy: Proxy? = null,
+    val delay: Int
 ) {
     data class Proxy(
-            val host: String,
-            val port: Int,
-            val user: String? = null,
-            val password: String? = null
+        val host: String,
+        val port: Int,
+        val user: String? = null,
+        val password: String? = null
     )
 }

--- a/appvox-core/src/main/kotlin/dev/fabiou/appvox/review/appstore/AppStoreReviewConverter.kt
+++ b/appvox-core/src/main/kotlin/dev/fabiou/appvox/review/appstore/AppStoreReviewConverter.kt
@@ -16,7 +16,7 @@ internal class AppStoreReviewConverter : ReviewConverter<AppStoreReviewResult.Ap
                 title = result.attributes.title,
                 comment = result.attributes.review,
                 commentTime = ZonedDateTime.parse(result.attributes.date),
-                replyComment = result.attributes.developerResponse?.body,
+                replyComment = result.attributes.developerResponse?.let { it.body },
                 replyTime = ZonedDateTime.parse(result.attributes.developerResponse?.modified),
             )
             reviews.add(review)

--- a/appvox-core/src/main/kotlin/dev/fabiou/appvox/review/appstore/domain/AppStoreReview.kt
+++ b/appvox-core/src/main/kotlin/dev/fabiou/appvox/review/appstore/domain/AppStoreReview.kt
@@ -24,11 +24,6 @@ data class AppStoreReview(
     val title: String? = null,
 
     /**
-     * iOS App Version
-     */
-    val appVersion: String? = null,
-
-    /**
      * Comment written by the user
      */
     val comment: String,

--- a/appvox-core/src/main/kotlin/dev/fabiou/appvox/review/googleplay/GooglePlayReviewConverter.kt
+++ b/appvox-core/src/main/kotlin/dev/fabiou/appvox/review/googleplay/GooglePlayReviewConverter.kt
@@ -8,10 +8,10 @@ import java.time.ZoneOffset
 import java.time.ZonedDateTime
 
 internal class GooglePlayReviewConverter :
-    ReviewConverter<GooglePlayReviewResult.GooglePlayReview, GooglePlayReview> {
+    ReviewConverter<GooglePlayReviewResult, GooglePlayReview> {
 
     override fun toResponse(
-        results: List<GooglePlayReviewResult.GooglePlayReview>
+        results: List<GooglePlayReviewResult>
     ): List<GooglePlayReview> {
         val reviews = ArrayList<GooglePlayReview>()
         results.forEach { result ->

--- a/appvox-core/src/main/kotlin/dev/fabiou/appvox/review/googleplay/GooglePlayReviewRepository.kt
+++ b/appvox-core/src/main/kotlin/dev/fabiou/appvox/review/googleplay/GooglePlayReviewRepository.kt
@@ -15,7 +15,7 @@ import dev.fabiou.appvox.util.JsonUtil.getJsonNodeByIndex
 
 internal class GooglePlayReviewRepository(
     private val config: RequestConfiguration
-) : ReviewRepository<GooglePlayReviewRequest, GooglePlayReviewResult.GooglePlayReview> {
+) : ReviewRepository<GooglePlayReviewRequest, GooglePlayReviewResult> {
     companion object {
         internal var REQUEST_URL_DOMAIN = "https://play.google.com"
         internal const val REQUEST_URL_PATH = "/_/PlayStoreUi/data/batchexecute"
@@ -50,7 +50,7 @@ internal class GooglePlayReviewRepository(
     @Throws(AppVoxException::class)
     override fun getReviewsByAppId(
         request: ReviewRequest<GooglePlayReviewRequest>
-    ): ReviewResult<GooglePlayReviewResult.GooglePlayReview> {
+    ): ReviewResult<GooglePlayReviewResult> {
         if (request.parameters.batchSize !in MIN_BATCH_SIZE..MAX_BATCH_SIZE) {
             throw AppVoxException(AppVoxError.INVALID_ARGUMENT)
         }
@@ -60,10 +60,10 @@ internal class GooglePlayReviewRepository(
             REQUEST_URL_PATH + REQUEST_URL_PARAMS.format(request.parameters.language.langCode)
         val responseContent = httpUtils.postRequest(requestUrl, requestBody, config.proxy)
 
-        val reviews = ArrayList<GooglePlayReviewResult.GooglePlayReview>()
+        val reviews = ArrayList<GooglePlayReviewResult>()
         val gplayReviews = parseReviewsFromResponse(responseContent)
         for (gplayReview in gplayReviews[0]) {
-            val review = GooglePlayReviewResult.GooglePlayReview(
+            val review = GooglePlayReviewResult(
                 reviewId = getJsonNodeByIndex(gplayReview, REVIEW_ID_INDEX).asText(),
                 userName = getJsonNodeByIndex(gplayReview, USER_NAME_INDEX).asText(),
                 userProfilePicUrl = getJsonNodeByIndex(gplayReview, USER_PROFILE_PIC_INDEX).asText(),

--- a/appvox-core/src/main/kotlin/dev/fabiou/appvox/review/googleplay/GooglePlayReviewService.kt
+++ b/appvox-core/src/main/kotlin/dev/fabiou/appvox/review/googleplay/GooglePlayReviewService.kt
@@ -9,13 +9,13 @@ import dev.fabiou.appvox.review.googleplay.domain.GooglePlayReviewResult
 
 internal class GooglePlayReviewService(
     val config: RequestConfiguration
-) : ReviewService<GooglePlayReviewRequest, GooglePlayReviewResult.GooglePlayReview> {
+) : ReviewService<GooglePlayReviewRequest, GooglePlayReviewResult> {
 
     private val googlePlayReviewRepository = GooglePlayReviewRepository(config)
 
     override fun getReviewsByAppId(
         request: ReviewRequest<GooglePlayReviewRequest>
-    ): ReviewResult<GooglePlayReviewResult.GooglePlayReview> {
+    ): ReviewResult<GooglePlayReviewResult> {
         return googlePlayReviewRepository.getReviewsByAppId(request)
     }
 }

--- a/appvox-core/src/main/kotlin/dev/fabiou/appvox/review/googleplay/domain/GooglePlayReviewResult.kt
+++ b/appvox-core/src/main/kotlin/dev/fabiou/appvox/review/googleplay/domain/GooglePlayReviewResult.kt
@@ -1,19 +1,19 @@
 package dev.fabiou.appvox.review.googleplay.domain
 
+//data class GooglePlayReviewResult(
+//    val reviews: List<GooglePlayReview>
+//) {
 data class GooglePlayReviewResult(
-    val reviews: List<GooglePlayReview>
-) {
-    data class GooglePlayReview(
-        val reviewId: String,
-        val userName: String,
-        val userProfilePicUrl: String,
-        val rating: Int,
-        val comment: String,
-        val submitTime: Long,
-        val likeCount: Int,
-        val reviewUrl: String,
-        val appVersion: String?,
-        val replyComment: String?,
-        val replySubmitTime: Long?
-    )
-}
+    val reviewId: String,
+    val userName: String,
+    val userProfilePicUrl: String,
+    val rating: Int,
+    val comment: String,
+    val submitTime: Long,
+    val likeCount: Int,
+    val reviewUrl: String,
+    val appVersion: String?,
+    val replyComment: String?,
+    val replySubmitTime: Long?
+)
+//}

--- a/appvox-core/src/main/kotlin/dev/fabiou/appvox/util/HttpUtil.kt
+++ b/appvox-core/src/main/kotlin/dev/fabiou/appvox/util/HttpUtil.kt
@@ -7,6 +7,11 @@ import java.net.*
 import java.net.Proxy.NO_PROXY
 import java.net.Proxy.Type.HTTP
 
+/**
+ * TODO Change custom proxy object to a more flexible java.net.Proxy
+ *
+ * @constructor Create empty Http util?
+ */
 internal object HttpUtil {
 
     private const val URL_FORM_CONTENT_TYPE = "application/x-www-form-urlencoded"

--- a/appvox-core/src/test/kotlin/UrlUtil.kt
+++ b/appvox-core/src/test/kotlin/UrlUtil.kt
@@ -1,6 +1,0 @@
-object UrlUtil {
-    fun getUrlDomainByEnv(defaultDomain: String) : String {
-        val isCiEnv: String? = System.getenv("TRAVIS")
-        return if (isCiEnv == null || isCiEnv.isEmpty()) "http://localhost:8080" else defaultDomain
-    }
-}

--- a/appvox-core/src/test/kotlin/dev/fabiou/appvox/AppStoreTest.kt
+++ b/appvox-core/src/test/kotlin/dev/fabiou/appvox/AppStoreTest.kt
@@ -26,7 +26,7 @@ class AppStoreTest : BaseMockTest() {
     @ExperimentalCoroutinesApi
     @ParameterizedTest
     @CsvSource(
-        "333903271, us, 1, 50"
+        "333903271, us, 10"
     )
     fun `get most recent App Store reviews with a delay of 3s between each request`(
         appId: String,
@@ -72,17 +72,22 @@ class AppStoreTest : BaseMockTest() {
     @ExperimentalCoroutinesApi
     @ParameterizedTest
     @CsvSource(
-        "333903271, us, 1, 50"
+        "333903271, us, 10"
     )
     fun `Get App Store reviews using default optional parameters`(
         appId: String,
-        region: String,
-        pageNo: Int,
+        regionCode: String,
         expectedReviewCount: Int
     ) = runBlockingTest {
         REQUEST_URL_DOMAIN = UrlUtil.getUrlDomainByEnv(REQUEST_URL_DOMAIN)
-        val mockData = javaClass.getResource("/review/itunes_rss/itunes_rss_reviews_mock_data.xml").readText()
-        stubHttpUrl(REQUEST_URL_PATH.format(region, pageNo, appId), mockData)
+        APP_HP_URL_DOMAIN = UrlUtil.getUrlDomainByEnv(APP_HP_URL_DOMAIN)
+
+        val region = fromValue(regionCode)
+        val bearerTokenRequestUrlPath = APP_HP_URL_PATH.format(region.code, appId)
+        stubHttpUrl(bearerTokenRequestUrlPath, "mock-bearer-token")
+
+        val mockData = javaClass.getResource("/review/app_store/appstore_reviews_mock_data.json").readText()
+        stubHttpUrl(REQUEST_URL_PATH.format(region.code, appId, AppStoreReviewRepository.REQUEST_REVIEW_SIZE), mockData)
 
         val reviews = ArrayList<AppStoreReview>()
         AppStore().reviews(appId)

--- a/appvox-core/src/test/kotlin/dev/fabiou/appvox/BaseMockTest.kt
+++ b/appvox-core/src/test/kotlin/dev/fabiou/appvox/BaseMockTest.kt
@@ -2,10 +2,14 @@ package dev.fabiou.appvox
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
-import org.junit.jupiter.api.*
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 open class BaseMockTest {
+
+    protected val httpMockServerDomain = "http://localhost:8080"
 
     private val wireMockServer = WireMockServer()
 

--- a/appvox-core/src/test/kotlin/dev/fabiou/appvox/GooglePlayTest.kt
+++ b/appvox-core/src/test/kotlin/dev/fabiou/appvox/GooglePlayTest.kt
@@ -1,6 +1,7 @@
 package dev.fabiou.appvox
 
-import UrlUtil
+import dev.fabiou.appvox.configuration.RequestConfiguration
+import dev.fabiou.appvox.configuration.RequestConfiguration.Proxy
 import dev.fabiou.appvox.review.googleplay.GooglePlayReviewRepository.Companion.REQUEST_URL_DOMAIN
 import dev.fabiou.appvox.review.googleplay.GooglePlayReviewRepository.Companion.REQUEST_URL_PATH
 import dev.fabiou.appvox.review.googleplay.constant.GooglePlayLanguage
@@ -18,6 +19,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.test.runBlockingTest
+import org.apache.http.client.config.RequestConfig
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
@@ -32,8 +34,10 @@ class GooglePlayTest : BaseMockTest() {
         appId: String,
         expectedReviewCount: Int
     ) = runBlockingTest {
-        REQUEST_URL_DOMAIN = UrlUtil.getUrlDomainByEnv(REQUEST_URL_DOMAIN)
-        val mockData = javaClass.getResource("/review/google_play/com.twitter.android/relevant/review_google_play_com.twitter.android_relevant_1.json").readText()
+        REQUEST_URL_DOMAIN = httpMockServerDomain
+        val mockData =
+            javaClass.getResource("/review/google_play/com.twitter.android/relevant/review_google_play_com.twitter.android_relevant_1.json")
+                .readText()
         stubHttpUrl(REQUEST_URL_PATH, mockData)
 
         val reviews = ArrayList<GooglePlayReview>()
@@ -55,7 +59,7 @@ class GooglePlayTest : BaseMockTest() {
                 likeCount.shouldBeGreaterThanOrEqual(0)
                 url shouldContain id
                 replyComment?.let { it.shouldNotBeEmpty() }
-//                replyTime?.let { it.shouldNotBeNull() }
+                // TODO replyTime?.let { it.shouldNotBeNull() }
             }
         }
     }
@@ -65,14 +69,16 @@ class GooglePlayTest : BaseMockTest() {
     @CsvSource(
         "com.twitter.android, en-US, 1, 50"
     )
-    fun `Get most relevant Google Play reviews from the US with a delay of 3s between each network call`(
+    fun `Get most relevant Google Play reviews from the US with a delay of 3s between each request`(
         appId: String,
         language: String,
         sortType: Int,
         expectedReviewCount: Int
     ) = runBlockingTest {
-        REQUEST_URL_DOMAIN = UrlUtil.getUrlDomainByEnv(REQUEST_URL_DOMAIN)
-        val mockResponse = javaClass.getResource("/review/google_play/com.twitter.android/relevant/review_google_play_com.twitter.android_relevant_1.json").readText()
+        REQUEST_URL_DOMAIN = httpMockServerDomain
+        val mockResponse =
+            javaClass.getResource("/review/google_play/com.twitter.android/relevant/review_google_play_com.twitter.android_relevant_1.json")
+                .readText()
         stubHttpUrl(REQUEST_URL_PATH, mockResponse)
 
         val reviews = ArrayList<GooglePlayReview>()
@@ -99,7 +105,7 @@ class GooglePlayTest : BaseMockTest() {
                 likeCount.shouldBeGreaterThanOrEqual(0)
                 url shouldContain id
                 replyComment?.let { it.shouldNotBeEmpty() }
-//                replyTime?.let { it.shouldNotBeNull() }
+                // TODO replyTime?.let { it.shouldNotBeNull() }
             }
         }
     }

--- a/appvox-core/src/test/kotlin/dev/fabiou/appvox/ItunesRssTest.kt
+++ b/appvox-core/src/test/kotlin/dev/fabiou/appvox/ItunesRssTest.kt
@@ -1,17 +1,16 @@
 package dev.fabiou.appvox
 
 import UrlUtil
-import dev.fabiou.appvox.app.appstore.AppStoreRepository.Companion.APP_HP_URL_DOMAIN
-import dev.fabiou.appvox.app.appstore.AppStoreRepository.Companion.APP_HP_URL_PATH
 import dev.fabiou.appvox.configuration.RequestConfiguration
-import dev.fabiou.appvox.review.appstore.AppStoreReviewRepository
-import dev.fabiou.appvox.review.appstore.AppStoreReviewRepository.Companion.REQUEST_URL_DOMAIN
-import dev.fabiou.appvox.review.appstore.AppStoreReviewRepository.Companion.REQUEST_URL_PATH
-import dev.fabiou.appvox.review.appstore.domain.AppStoreReview
+import dev.fabiou.appvox.review.itunesrss.ItunesRssReviewRepository.Companion.REQUEST_URL_DOMAIN
+import dev.fabiou.appvox.review.itunesrss.ItunesRssReviewRepository.Companion.REQUEST_URL_PATH
 import dev.fabiou.appvox.review.itunesrss.constant.AppStoreRegion.Companion.fromValue
+import dev.fabiou.appvox.review.itunesrss.constant.ItunesRssSortType
+import dev.fabiou.appvox.review.itunesrss.domain.ItunesRssReview
 import io.kotest.assertions.assertSoftly
 import io.kotest.inspectors.forExactly
 import io.kotest.matchers.ints.shouldBeBetween
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.string.shouldNotBeEmpty
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -21,60 +20,14 @@ import kotlinx.coroutines.test.runBlockingTest
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
-class AppStoreTest : BaseMockTest() {
+class ItunesRssTest : BaseMockTest() {
 
     @ExperimentalCoroutinesApi
     @ParameterizedTest
     @CsvSource(
         "333903271, us, 1, 50"
     )
-    fun `get most recent App Store reviews with a delay of 3s between each request`(
-        appId: String,
-        regionCode: String,
-        expectedReviewCount: Int
-    ) = runBlockingTest {
-        REQUEST_URL_DOMAIN = UrlUtil.getUrlDomainByEnv(REQUEST_URL_DOMAIN)
-        APP_HP_URL_DOMAIN = UrlUtil.getUrlDomainByEnv(APP_HP_URL_DOMAIN)
-
-        val region = fromValue(regionCode)
-        val bearerTokenRequestUrlPath = APP_HP_URL_PATH.format(region.code, appId)
-        stubHttpUrl(bearerTokenRequestUrlPath, "mock-bearer-token")
-
-        val mockData = javaClass.getResource("/review/app_store/appstore_reviews_mock_data.json").readText()
-        stubHttpUrl(REQUEST_URL_PATH.format(region.code, appId, AppStoreReviewRepository.REQUEST_REVIEW_SIZE), mockData)
-
-        val reviews = arrayListOf<AppStoreReview>()
-        val appStore = AppStore(RequestConfiguration(delay = 3000))
-        appStore.reviews(
-            appId = appId,
-            region = region)
-            .take(expectedReviewCount)
-            .collect { review ->
-                reviews.add(review)
-            }
-
-        reviews.forExactly(expectedReviewCount) { result ->
-            assertSoftly(result) {
-                id.shouldNotBeEmpty()
-                userName.shouldNotBeEmpty()
-                rating.shouldBeBetween(1, 5)
-                title.shouldNotBeEmpty()
-                comment.shouldNotBeEmpty()
-                translatedComment?.let { it.shouldNotBeEmpty() }
-                commentTime.shouldNotBeNull()
-                replyComment?.let { it.shouldNotBeEmpty() }
-                replyTime?.let { it.shouldNotBeNull() }
-// TODO               url.shouldNotBeEmpty()
-            }
-        }
-    }
-
-    @ExperimentalCoroutinesApi
-    @ParameterizedTest
-    @CsvSource(
-        "333903271, us, 1, 50"
-    )
-    fun `Get App Store reviews using default optional parameters`(
+    fun `get most recent iTunes RSS Feed reviews with a delay of 3s between each request`(
         appId: String,
         region: String,
         pageNo: Int,
@@ -84,8 +37,13 @@ class AppStoreTest : BaseMockTest() {
         val mockData = javaClass.getResource("/review/itunes_rss/itunes_rss_reviews_mock_data.xml").readText()
         stubHttpUrl(REQUEST_URL_PATH.format(region, pageNo, appId), mockData)
 
-        val reviews = ArrayList<AppStoreReview>()
-        AppStore().reviews(appId)
+        val reviews = arrayListOf<ItunesRssReview>()
+        val appStore = ItunesRss(RequestConfiguration(delay = 3000))
+        appStore.reviews(
+            appId = appId,
+            region = fromValue(region),
+            sortType = ItunesRssSortType.RECENT
+        )
             .take(expectedReviewCount)
             .collect { review ->
                 reviews.add(review)
@@ -96,13 +54,51 @@ class AppStoreTest : BaseMockTest() {
                 id.shouldNotBeEmpty()
                 userName.shouldNotBeEmpty()
                 rating.shouldBeBetween(1, 5)
+                appVersion.shouldNotBeEmpty()
                 title.shouldNotBeEmpty()
                 comment.shouldNotBeEmpty()
                 translatedComment?.let { it.shouldNotBeEmpty() }
                 commentTime.shouldNotBeNull()
-                replyComment?.let { it.shouldNotBeEmpty() }
-                replyTime?.let { it.shouldNotBeNull() }
-//   TODO             url.shouldNotBeEmpty()
+                likeCount?.shouldBeGreaterThanOrEqual(0)
+                url.shouldNotBeEmpty()
+            }
+        }
+    }
+
+    @ExperimentalCoroutinesApi
+    @ParameterizedTest
+    @CsvSource(
+        "333903271, us, 1, 50"
+    )
+    fun `Get iTunes RSS Feed reviews using default optional parameters`(
+        appId: String,
+        region: String,
+        pageNo: Int,
+        expectedReviewCount: Int
+    ) = runBlockingTest {
+        REQUEST_URL_DOMAIN = UrlUtil.getUrlDomainByEnv(REQUEST_URL_DOMAIN)
+        val mockData = javaClass.getResource("/review/itunes_rss/itunes_rss_reviews_mock_data.xml").readText()
+        stubHttpUrl(REQUEST_URL_PATH.format(region, pageNo, appId), mockData)
+
+        val reviews = ArrayList<ItunesRssReview>()
+        ItunesRss().reviews(appId)
+            .take(expectedReviewCount)
+            .collect { review ->
+                reviews.add(review)
+            }
+
+        reviews.forExactly(expectedReviewCount) { result ->
+            assertSoftly(result) {
+                id.shouldNotBeEmpty()
+                userName.shouldNotBeEmpty()
+                rating.shouldBeBetween(1, 5)
+                appVersion.shouldNotBeEmpty()
+                title.shouldNotBeEmpty()
+                comment.shouldNotBeEmpty()
+                translatedComment?.let { it.shouldNotBeEmpty() }
+                commentTime.shouldNotBeNull()
+                likeCount?.shouldBeGreaterThanOrEqual(0)
+                url.shouldNotBeEmpty()
             }
         }
     }

--- a/appvox-core/src/test/kotlin/dev/fabiou/appvox/ItunesRssTest.kt
+++ b/appvox-core/src/test/kotlin/dev/fabiou/appvox/ItunesRssTest.kt
@@ -1,7 +1,7 @@
 package dev.fabiou.appvox
 
-import UrlUtil
 import dev.fabiou.appvox.configuration.RequestConfiguration
+import dev.fabiou.appvox.configuration.RequestConfiguration.Proxy
 import dev.fabiou.appvox.review.itunesrss.ItunesRssReviewRepository.Companion.REQUEST_URL_DOMAIN
 import dev.fabiou.appvox.review.itunesrss.ItunesRssReviewRepository.Companion.REQUEST_URL_PATH
 import dev.fabiou.appvox.review.itunesrss.constant.AppStoreRegion.Companion.fromValue
@@ -27,23 +27,18 @@ class ItunesRssTest : BaseMockTest() {
     @CsvSource(
         "333903271, us, 1, 50"
     )
-    fun `get most recent iTunes RSS Feed reviews with a delay of 3s between each request`(
+    fun `Get iTunes RSS Feed reviews using default optional parameters`(
         appId: String,
         region: String,
         pageNo: Int,
         expectedReviewCount: Int
     ) = runBlockingTest {
-        REQUEST_URL_DOMAIN = UrlUtil.getUrlDomainByEnv(REQUEST_URL_DOMAIN)
+        REQUEST_URL_DOMAIN = httpMockServerDomain
         val mockData = javaClass.getResource("/review/itunes_rss/itunes_rss_reviews_mock_data.xml").readText()
         stubHttpUrl(REQUEST_URL_PATH.format(region, pageNo, appId), mockData)
 
-        val reviews = arrayListOf<ItunesRssReview>()
-        val appStore = ItunesRss(RequestConfiguration(delay = 3000))
-        appStore.reviews(
-            appId = appId,
-            region = fromValue(region),
-            sortType = ItunesRssSortType.RECENT
-        )
+        val reviews = ArrayList<ItunesRssReview>()
+        ItunesRss().reviews(appId)
             .take(expectedReviewCount)
             .collect { review ->
                 reviews.add(review)
@@ -70,18 +65,23 @@ class ItunesRssTest : BaseMockTest() {
     @CsvSource(
         "333903271, us, 1, 50"
     )
-    fun `Get iTunes RSS Feed reviews using default optional parameters`(
+    fun `get most recent iTunes RSS Feed reviews with a delay of 3s between each request`(
         appId: String,
         region: String,
         pageNo: Int,
         expectedReviewCount: Int
     ) = runBlockingTest {
-        REQUEST_URL_DOMAIN = UrlUtil.getUrlDomainByEnv(REQUEST_URL_DOMAIN)
+        REQUEST_URL_DOMAIN = httpMockServerDomain
         val mockData = javaClass.getResource("/review/itunes_rss/itunes_rss_reviews_mock_data.xml").readText()
         stubHttpUrl(REQUEST_URL_PATH.format(region, pageNo, appId), mockData)
 
-        val reviews = ArrayList<ItunesRssReview>()
-        ItunesRss().reviews(appId)
+        val reviews = arrayListOf<ItunesRssReview>()
+        val appStore = ItunesRss(RequestConfiguration(delay = 3000))
+        appStore.reviews(
+            appId = appId,
+            region = fromValue(region),
+            sortType = ItunesRssSortType.RECENT
+        )
             .take(expectedReviewCount)
             .collect { review ->
                 reviews.add(review)

--- a/appvox-core/src/test/kotlin/dev/fabiou/appvox/app/appstore/AppStoreRepositoryTest.kt
+++ b/appvox-core/src/test/kotlin/dev/fabiou/appvox/app/appstore/AppStoreRepositoryTest.kt
@@ -17,8 +17,8 @@ class AppStoreRepositoryTest : BaseMockTest() {
     @CsvSource(
         "333903271, us, 10"
     )
-    fun `Get App Store bearer token`(appId: String, regionCode: String) {
-        APP_HP_URL_DOMAIN = UrlUtil.getUrlDomainByEnv(APP_HP_URL_DOMAIN)
+    fun `get App Store bearer token`(appId: String, regionCode: String) {
+        APP_HP_URL_DOMAIN = httpMockServerDomain
         val region = AppStoreRegion.fromValue(regionCode)
         stubHttpUrl(APP_HP_URL_PATH.format(region.code, appId), "mock-bearer-token")
 

--- a/appvox-core/src/test/kotlin/dev/fabiou/appvox/review/appstore/AppStoreReviewRepositoryTest.kt
+++ b/appvox-core/src/test/kotlin/dev/fabiou/appvox/review/appstore/AppStoreReviewRepositoryTest.kt
@@ -1,5 +1,6 @@
 package dev.fabiou.appvox.review.appstore
 
+import com.fasterxml.jackson.databind.JsonNode
 import dev.fabiou.appvox.BaseMockTest
 import dev.fabiou.appvox.app.appstore.AppStoreRepository
 import dev.fabiou.appvox.app.appstore.AppStoreRepository.Companion.APP_HP_URL_DOMAIN
@@ -80,7 +81,7 @@ class AppStoreReviewRepositoryTest : BaseMockTest() {
                 attributes.rating.shouldBeBetween(1, 5)
                 attributes.developerResponse?.let { developerResponse ->
                     developerResponse.body.shouldNotBeEmpty()
-//                    developerResponse.modified
+                // TODO developerResponse.modified
                 }
             }
         }

--- a/appvox-core/src/test/kotlin/dev/fabiou/appvox/review/appstore/AppStoreReviewRepositoryTest.kt
+++ b/appvox-core/src/test/kotlin/dev/fabiou/appvox/review/appstore/AppStoreReviewRepositoryTest.kt
@@ -1,6 +1,5 @@
 package dev.fabiou.appvox.review.appstore
 
-import com.fasterxml.jackson.databind.JsonNode
 import dev.fabiou.appvox.BaseMockTest
 import dev.fabiou.appvox.app.appstore.AppStoreRepository
 import dev.fabiou.appvox.app.appstore.AppStoreRepository.Companion.APP_HP_URL_DOMAIN
@@ -14,19 +13,12 @@ import dev.fabiou.appvox.review.appstore.domain.AppStoreReviewRequest
 import dev.fabiou.appvox.review.itunesrss.constant.AppStoreRegion
 import io.kotest.assertions.assertSoftly
 import io.kotest.inspectors.forExactly
-import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.ints.shouldBeBetween
-import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
-import io.kotest.matchers.longs.shouldBeBetween
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
-import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldContainOnlyDigits
 import io.kotest.matchers.string.shouldNotBeEmpty
-import io.kotest.matchers.string.shouldStartWith
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
@@ -46,8 +38,8 @@ class AppStoreReviewRepositoryTest : BaseMockTest() {
         regionCode: String,
         expectedReviewCount: Int
     ) {
-        REQUEST_URL_DOMAIN = UrlUtil.getUrlDomainByEnv(REQUEST_URL_DOMAIN)
-        APP_HP_URL_DOMAIN = UrlUtil.getUrlDomainByEnv(APP_HP_URL_DOMAIN)
+        REQUEST_URL_DOMAIN = httpMockServerDomain
+        APP_HP_URL_DOMAIN = httpMockServerDomain
 
         val region = AppStoreRegion.fromValue(regionCode)
         stubHttpUrl(APP_HP_URL_PATH.format(region.code, appId), "mock-bearer-token")

--- a/appvox-core/src/test/kotlin/dev/fabiou/appvox/review/googleplay/GooglePlayReviewRepositoryTest.kt
+++ b/appvox-core/src/test/kotlin/dev/fabiou/appvox/review/googleplay/GooglePlayReviewRepositoryTest.kt
@@ -1,6 +1,5 @@
 package dev.fabiou.appvox.review.googleplay
 
-import UrlUtil
 import dev.fabiou.appvox.BaseMockTest
 import dev.fabiou.appvox.configuration.RequestConfiguration
 import dev.fabiou.appvox.review.ReviewRequest
@@ -12,10 +11,8 @@ import dev.fabiou.appvox.review.googleplay.domain.GooglePlayReviewRequest
 import io.kotest.assertions.assertSoftly
 import io.kotest.inspectors.forExactly
 import io.kotest.matchers.ints.shouldBeBetween
-import io.kotest.matchers.ints.shouldBeExactly
 import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.longs.shouldBeBetween
-import io.kotest.matchers.string.shouldBeEmpty
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotBeEmpty
 import io.kotest.matchers.string.shouldStartWith
@@ -39,7 +36,7 @@ class GooglePlayReviewRepositoryTest : BaseMockTest() {
         batchSize: Int,
         expectedReviewCount: Int
     ) {
-        REQUEST_URL_DOMAIN = UrlUtil.getUrlDomainByEnv(REQUEST_URL_DOMAIN)
+        REQUEST_URL_DOMAIN = httpMockServerDomain
         val mockData =
             javaClass.getResource("/review/google_play/com.twitter.android/relevant/review_google_play_com.twitter.android_relevant_1.json")
                 .readText()

--- a/appvox-core/src/test/kotlin/dev/fabiou/appvox/review/itunesrss/ItunesRssReviewRepositoryTest.kt
+++ b/appvox-core/src/test/kotlin/dev/fabiou/appvox/review/itunesrss/ItunesRssReviewRepositoryTest.kt
@@ -51,6 +51,7 @@ class ItunesRssReviewRepositoryTest : BaseMockTest() {
                 id.shouldNotBeEmpty()
                 id.shouldContainOnlyDigits()
                 title.shouldNotBeEmpty()
+                // TODO Cover other fields
             }
         }
         response.nextToken.shouldNotBeEmpty()

--- a/appvox-core/src/test/kotlin/dev/fabiou/appvox/review/itunesrss/ItunesRssReviewRepositoryTest.kt
+++ b/appvox-core/src/test/kotlin/dev/fabiou/appvox/review/itunesrss/ItunesRssReviewRepositoryTest.kt
@@ -1,6 +1,5 @@
 package dev.fabiou.appvox.review.itunesrss
 
-import UrlUtil
 import dev.fabiou.appvox.BaseMockTest
 import dev.fabiou.appvox.configuration.RequestConfiguration
 import dev.fabiou.appvox.review.ReviewRequest
@@ -32,7 +31,7 @@ class ItunesRssReviewRepositoryTest : BaseMockTest() {
         expectedReviewCount: Int,
         pageNo: Int
     ) {
-        REQUEST_URL_DOMAIN = UrlUtil.getUrlDomainByEnv(REQUEST_URL_DOMAIN)
+        REQUEST_URL_DOMAIN = httpMockServerDomain
         val region = AppStoreRegion.fromValue(regionCode)
         val mockData = javaClass.getResource("/review/itunes_rss/itunes_rss_reviews_mock_data.xml").readText()
         stubHttpUrl(REQUEST_URL_PATH.format(region.code, pageNo, appId), mockData)

--- a/appvox-examples/src/main/kotlin/com/examples/review/itunesrss/ExportItunesRssReviewsToCsv.kt
+++ b/appvox-examples/src/main/kotlin/com/examples/review/itunesrss/ExportItunesRssReviewsToCsv.kt
@@ -1,7 +1,7 @@
-package com.examples.review.appstore
+package com.examples.review.itunesrss
 
 import com.opencsv.CSVWriter
-import dev.fabiou.appvox.AppStore
+import dev.fabiou.appvox.ItunesRss
 import dev.fabiou.appvox.configuration.RequestConfiguration
 import dev.fabiou.appvox.exception.AppVoxException
 import dev.fabiou.appvox.review.itunesrss.constant.AppStoreRegion
@@ -41,7 +41,7 @@ fun main() = runBlocking {
             delay = 3000
         )
 
-        val appStore = AppStore(config)
+        val appStore = ItunesRss(config)
         appStore.reviews(
                 appId = appId,
                 region = AppStoreRegion.fromValue(userRegion),

--- a/appvox-examples/src/main/kotlin/com/examples/review/itunesrss/MinimalPrintItunesRssReviews.kt
+++ b/appvox-examples/src/main/kotlin/com/examples/review/itunesrss/MinimalPrintItunesRssReviews.kt
@@ -1,12 +1,12 @@
-package com.examples.review.appstore
+package com.examples.review.itunesrss
 
-import dev.fabiou.appvox.AppStore
+import dev.fabiou.appvox.ItunesRss
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.runBlocking
 
 fun main() = runBlocking {
-    AppStore().reviews("333903271")
+    ItunesRss().reviews("333903271")
         .take(100)
         .collect { review ->
             println(review.toString())

--- a/appvox-examples/src/main/kotlin/com/examples/review/itunesrss/PrintFormattedItunesRssReviews.kt
+++ b/appvox-examples/src/main/kotlin/com/examples/review/itunesrss/PrintFormattedItunesRssReviews.kt
@@ -1,6 +1,6 @@
-package com.examples.review.appstore
+package com.examples.review.itunesrss
 
-import dev.fabiou.appvox.AppStore
+import dev.fabiou.appvox.ItunesRss
 import dev.fabiou.appvox.configuration.RequestConfiguration
 import dev.fabiou.appvox.review.itunesrss.constant.AppStoreRegion
 import dev.fabiou.appvox.review.itunesrss.constant.ItunesRssSortType
@@ -25,7 +25,7 @@ fun main() = runBlocking {
     val config = RequestConfiguration(
         delay = 3000
     )
-    val appStore = AppStore(config)
+    val appStore = ItunesRss(config)
     appStore.reviews(
             appId = appId,
             region = AppStoreRegion.fromValue(userRegion),

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,12 @@
                 <version>${kotlin.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-reflect</artifactId>
+                <version>${kotlin.version}</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.jetbrains.kotlinx</groupId>
                 <artifactId>kotlinx-coroutines-core</artifactId>
                 <version>${kotlin.coroutines.version}</version>
@@ -74,6 +80,12 @@
                 <groupId>com.fasterxml.jackson.module</groupId>
                 <artifactId>jackson-module-kotlin</artifactId>
                 <version>2.11.0</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-reflect</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- Test Dependencies-->
             <dependency>
@@ -93,6 +105,12 @@
                 <groupId>com.github.tomakehurst</groupId>
                 <artifactId>wiremock</artifactId>
                 <version>${wiremock.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.kotest</groupId>
+                <artifactId>kotest-assertions-core-jvm</artifactId>
+                <version>4.4.3</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
### Changes done
- Create a separate facade to scrape App Store reviews
- Remove wrapping entity around GooglePlayReviewResult